### PR TITLE
fix: fixed the screenshot not showing in github issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,7 +40,6 @@ body:
       description: If applicable, add screenshots to help explain your problem.
       placeholder: |
         ![DESCRIPTION](LINK.png)
-      render: bash
     validations:
       required: false
   - type: checkboxes


### PR DESCRIPTION
## Title :
Fixed the issue where screenshots werent loading in github issues

## Issue no : 
#10 

## Description
when making an issue in the repos, we aren't able to paste images in the screenshot or even if we write the markdown for images still its not loading.
 
so I removed `render: bash` from config.yml and now images and screenshots will load

## Screenshots (if applicable)
![image](https://github.com/tcet-opensource/.github/assets/53911515/0da7981b-3e67-430b-b9cb-7b855aa12568)

![image](https://github.com/tcet-opensource/.github/assets/53911515/76bc3907-a39c-44f5-9e32-75b6cd1bd051)

## Checklist
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/tcet-opensource/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have read and followed the **Contributing Guidelines**