### PR TITLE
added github sponsors to the FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,3 @@
 ko_fi: tcetopensource
 patreon: tcetopensource
+github: himanshu-03


### PR DESCRIPTION
## Title :
Added github sponsors account to FUNDING.yml
## Issue no : 
nil
## Description
Needed github spons account to accept sponsor amounts from outside orgs
## Screenshots (if applicable)
![image](https://github.com/tcet-opensource/.github/assets/63772910/a1acdb2a-133b-4bc2-8fe2-7ac8e7595006)

## Checklist
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/tcet-opensource/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have read and followed the **Contributing Guidelines**